### PR TITLE
Add package.json to editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,7 @@ insert_final_newline = true
 
 [*.md]
 trim_trailing_whitespace = false
+
+[package.json]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
Allows auto-formatting `package.json` correctly after manual changes
