### PR TITLE
Wrap refs call with ReactDOM.findDOMNode() to focus button

### DIFF
--- a/client/scripts/application.js
+++ b/client/scripts/application.js
@@ -4,7 +4,7 @@ import { Button, Form, FormField, FormInput } from 'elemental';
 
 const App = React.createClass({
 	componentDidMount () {
-		this.refs.btn.focus();
+		ReactDOM.findDOMNode(this.refs.btn).focus();
 	},
 	gotoKeystone () {
 		window.location.href = '/keystone';


### PR DESCRIPTION
 since ref is tied to a React component.

The bug is shown in these screenshot and this fix allows the button to be focused correctly.

<img width="1265" alt="screen shot 2015-11-19 at 10 47 30 pm" src="https://cloud.githubusercontent.com/assets/21967/11292232/7f156728-8f10-11e5-8dce-89246eb6f7aa.png">
<img width="1273" alt="screen shot 2015-11-19 at 10 37 57 pm" src="https://cloud.githubusercontent.com/assets/21967/11292231/7f11cdc0-8f10-11e5-8ee8-e04edaaa6547.png">
