### PR TITLE
Add npm run start:iron command

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "connect-flash": "^0.1.1",
     "elemental": "^0.5.12",
     "express": "^4.13.4",
+    "iron-node": "^2.2.16",
     "jade": "^1.11.0",
     "keystone": "https://github.com/keystonejs/keystone.git",
     "lorem-ipsum": "^1.0.3",
@@ -36,6 +37,7 @@
   },
   "scripts": {
     "start": "node keystone.js",
+    "start:iron": "KEYSTONE_DEV=true iron-node keystone.js",
     "dev": "KEYSTONE_DEV=true node keystone.js",
     "dev_windows": "set KEYSTONE_DEV=true&&node keystone.js"
   },


### PR DESCRIPTION
iron-node is a utility that runs the chrome devtools in electron as a standalone window, hooking into node.js.

This means you can **use the Chrome DevTools to develop keystone**, which is amazing. Access to a proper console, breakpoints, debuggers, everything!
