### PR TITLE
List Permissions Proposal

### DIFF
--- a/models/Post.js
+++ b/models/Post.js
@@ -23,6 +23,38 @@ Post.schema.virtual('content.full').get(() => {
 	return this.content.extended || this.content.brief;
 });
 
+Post.userFieldOptions = (user) => ({
+	state: {
+		// normal users cannot change the state of a post
+		noedit: !user.isEditor,
+	},
+	author: {
+		// author is hidden from normal users
+		hidden: !user.isEditor,
+	},
+});
+
+Post.itemFieldOptions = (item, user) => ({
+	name: {
+		// non-editors cannot change the name of a published post
+		noedit: item.state === 'published' && !user.isEditor,
+	},
+});
+
+Post.modifyListQuery = (user, query) => {
+	if (!user.isEditor) {
+		// normal users can only get / update / delete their own posts
+		query.where('author', user.id);
+	}
+};
+
+Post.modifyItemData = (user, post) => {
+	if (!user.isEditor) {
+		// normal users will always be set as the author of posts they create
+		post.author = user.id;
+	}
+};
+
 transform.toJSON(Post);
 Post.defaultColumns = 'name, state|20%, author|20%, categories|20%, publishedDate|20%';
 Post.register();


### PR DESCRIPTION
This is a proposed implementation of List Permissions that may be supported by Keystone.

To explain what's going on:
## Idea 1

You can dynamically change list and field options (specifically `hidden`, `noedit` and `nodelete`) based on the current user / item data. This lets you customise what's displayed in the Admin UI for a particular user (could be a permission group)

To do this, you can set the following methods on the List instance:

``` js
userOptions (user) => { /* list options to override for the user */ } 
userFieldOptions (user) => { /* field paths containing options to override for each field */ }
itemOptions (item, user) => { /* list options to override on a per-item basis */ }
itemFieldOptions (item, user) => { /* field paths containing options to override on a per-item basis */ }
```
## Idea 2

You can directly modify the queries used (after filters are applied) for Admin UI endpoints, including:
- get item(s)
- update item(s)
- delete item(s)
- download export

You could use this, for example, to limit which items a user can see or interact with in any way.

To do this, you could set the following methods on the List instance:

``` js
modifyListQuery (user, query) // modify the query by reference, based on the current user
modifyItemData (user, item) // update properties on the item before it is saved
```
## Example use case

This PR implements these features to achieve two use cases:
- Protecting the demo user from being updated or deleted using generic functionality
- Adding a concept of Editor Users, and implementing restrictions on Posts, where non-editors can only see their own posts, can't change the state of a post, and can't edit certain fields after the post has been published
