### PR TITLE
initDatabase() was renamed to initDatabaseConfig()

### DIFF
--- a/express.js
+++ b/express.js
@@ -20,7 +20,7 @@ keystone.set('locals', config.locals);
 keystone.set('routes', require('./routes'));
 keystone.set('nav', config.nav);
 
-keystone.initDatabase();
+keystone.initDatabaseConfig();
 keystone.initExpressSession();
 
 app.use(compression());


### PR DESCRIPTION
[This commit](https://github.com/keystonejs/keystone/commit/591240b8e424e2708e97e5304378e8675cb7d7ee) renamed `keystone.initDatabase()` to `keystone.initDatabaseConfig()`, so this should fix this part of the test project.
