### PR TITLE
feat(setup): add setup script to clone and link keystone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ uploads
 
 # Ignore private keys + config
 .secrets
+keystone/

--- a/.scripts/setup.bash
+++ b/.scripts/setup.bash
@@ -1,0 +1,7 @@
+DEFAULT_REPO="git@github.com:keystonejs/keystone.git"
+if [[ $(ls | grep -c "^keystone$") -eq 0 ]]; then
+	git clone "${1-$DEFAULT_REPO}"
+fi
+
+rm -rf node_modules/keystone
+npm link ./keystone

--- a/README.md
+++ b/README.md
@@ -3,3 +3,25 @@
 A KeystoneJS Project with various configurations for development and testing purposes
 
 **Note: This project requires Node.js v4.x or newer**
+
+By following the setup instructions, you will have a cloned instance of the keystone repository in a root level folder named `keystone`. This folder is gitignored, so changes to it will not be tracked in this project.
+
+This setup will allow you to use the "test-project" as a test-bed for changes to keystone. You can edit the keystone project, commit to it as normal and verify the changes in the test-project during development.
+
+# Setup Instructions
+
+## Pre-Requisites
+
+* git
+* node
+* npm
+
+## MacOS / Linux / Any system with BASH
+
+* `npm run setup`
+
+## Windows / Other
+
+* git clone git@github.com:keystonejs/keystone.git
+* rm -rf node_modules/keystone
+* npm link ./keystone

--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
     "express": "^4.13.4",
     "iron-node": "^3.0.5",
     "jade": "^1.11.0",
-    "keystone": "https://github.com/keystonejs/keystone.git",
     "keystone-storage-adapter-azure": "^1.1.0",
     "keystone-storage-adapter-s3": "^1.1.0",
     "keystone-utils": "^0.4.0",
+    "lodash": "4.17.2",
     "lorem-ipsum": "^1.0.3",
     "model-transform": "^2.0.0",
     "morgan": "^1.7.0",
@@ -46,12 +46,16 @@
     "start": "node keystone.js",
     "start:no-csrf": "KEYSTONE_DEV=true DISABLE_CSRF=true node keystone.js",
     "start:iron": "KEYSTONE_DEV=true iron-node keystone.js",
-    "test": "npm run lint"
+    "test": "npm run lint",
+    "setup": "bash ./.scripts/setup.bash"
   },
   "main": "keystone.js",
   "devDependencies": {
     "eslint": "^2.11.1",
     "eslint-config-keystone": "^2.2.0",
     "eslint-plugin-react": "^5.1.1"
+  },
+  "peerDependencies": {
+    "keystone": "*"
   }
 }


### PR DESCRIPTION
move keystone to peerDependencies so that working with custom keystone
installs is simpler

add a setup script in bash that will clone the keystone master branch to
the ./keystone folder in the root of the project, and then npm-link this
cloned keystone into the test project